### PR TITLE
Fix for 32-bit floats. Closes #7.

### DIFF
--- a/lib/gridfill/gridfill.py
+++ b/lib/gridfill/gridfill.py
@@ -48,6 +48,7 @@ def _prep_data(grid, xdim, ydim):
     intshape = grid.shape
     grid = grid.reshape(grid.shape[:2] + (np.prod(grid.shape[2:]),))
     info = dict(intshape=intshape, intorder=intorder, origndim=origndim)
+    grid = grid.astype(np.float64)
     return grid, info
 
 

--- a/lib/gridfill/tests/test_fill.py
+++ b/lib/gridfill/tests/test_fill.py
@@ -83,6 +83,17 @@ class GridFillTest(object):
         np.testing.assert_array_almost_equal(a, b)
 
 
+class TestFloat32(GridFillTest):
+    """Test with 32-bit float input."""
+    cyclic = False
+    initzonal = False
+
+    @classmethod
+    def setup_class(cls):
+        cls.grid, cls.soln = reference_solution(cls.cyclic, cls.initzonal)
+        cls.grid = cls.grid.astype(np.float32)
+
+
 class TestFillNonCyclicInitZero(GridFillTest):
     """Non-cyclic, initialized with zeros."""
     cyclic = False


### PR DESCRIPTION
This PR makes sure that grids are cast to 64-bit floats before being passed to the underlying Fortran code.
