### PR TITLE
Must be a list instead of a generator to use `.remove`.

### DIFF
--- a/lib/gridfill/gridfill.py
+++ b/lib/gridfill/gridfill.py
@@ -28,7 +28,7 @@ from gridfill_f import poisson_fill_grids as _poisson_fill_grids
 
 
 def _order_dims(grid, xpos, ypos):
-    outorder = range(grid.ndim)
+    outorder = list(range(grid.ndim))
     try:
         outorder.remove(xpos)
         outorder.remove(ypos)


### PR DESCRIPTION
Minor fix to make gridfill py3k compatible.
