### PR TITLE
Add initzonal_linear option in the initialization part

### DIFF
--- a/gridfill/gridfill.py
+++ b/gridfill/gridfill.py
@@ -64,8 +64,8 @@ def _recover_data(grid, info):
     return grid
 
 
-def fill(grids, xdim, ydim, eps, relax=.6, itermax=100, initzonal=False,
-         cyclic=False, verbose=False):
+def fill(grids, xdim, ydim, eps, relax=.6, itermax=100, initzonal=False, initzonal_linear=False,
+         cyclic=False, initial_value=0.0, verbose=False):
     """
     Fill missing values in grids with values derived by solving
     Poisson's equation using a relaxation scheme.
@@ -97,6 +97,11 @@ def fill(grids, xdim, ydim, eps, relax=.6, itermax=100, initzonal=False,
         missing values will be initialized to the zonal mean. Defaults
         to *False*.
 
+    *initzonal_linear*
+        If *False* missing values will be initialized to zero, if *True*
+        missing values will be initialized to the zonal mean. Defaults
+        to *False*.
+
     *cyclic*
         Set to *False* if the x-coordinate of the grid is not cyclic,
         set to *True* if it is cyclic. Defaults to *False*.
@@ -119,7 +124,9 @@ def fill(grids, xdim, ydim, eps, relax=.6, itermax=100, initzonal=False,
     # Call the computation subroutine:
     niter, resmax = _poisson_fill_grids(grids, masks, relax, eps, itermax,
                                         1 if cyclic else 0,
-                                        1 if initzonal else 0)
+                                        1 if initzonal else 0,
+                                        1 if initzonal_linear else 0,
+                                        initial_value)
     grids = _recover_data(grids, info)
     converged = np.logical_not(resmax > eps)
     # optional performance information:


### PR DESCRIPTION
Add initzonal_linear option in the initialization part 
which is alternative to the original initzonal option.
The initzonal_linear option allow one to initialize the
missing data with linearly-interpolated value along zonal
direction, by which the converge iteration will be
significantly reduced and the filled results will be more
smooth in some circumstances.
In addition, an initial_value can by used for the case in
which most of the array are missing, and neither initzonal_linear
nor initzonal option still work.